### PR TITLE
_relativePath handler fix

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.0.6 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fixes _relativePath handler
+  [petschki]
 
 
 1.0.5 (2012-06-29)
@@ -12,9 +13,9 @@ Changelog
 
 - Date ranges now use the _betweenDates handler, which is much more forgiving
   of empty field values, defaulting to an all-encompassing date range if neither
-  value is provided, an "everything after" range if only the start date is 
+  value is provided, an "everything after" range if only the start date is
   provided, and a min/max range if both are provided.
-  
+
   Fixes http://dev.plone.org/ticket/12965
   [esteele]
 
@@ -34,7 +35,7 @@ Changelog
   results not wrapped as an IContentListing.
   [davisagli]
 
-* Declare all dependencies in setup.py to resolve a dependeny problem in 
+* Declare all dependencies in setup.py to resolve a dependeny problem in
   test setups, where the Plone stack isn't fully loaded.
   [thet]
 

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -12,6 +12,7 @@ from zope.publisher.browser import BrowserView
 
 from plone.app.querystring import queryparser
 from plone.app.querystring.interfaces import IQuerystringRegistryReader
+import logging
 
 _ = MessageFactory('plone')
 


### PR DESCRIPTION
ok, maybe someone can look at this, because as mentioned here (https://dev.plone.org/ticket/13012) the relative path index isn't working.

this fix can only work if archetypes.querywidget will be fixed too, so that "@@querybuilder_html_results" isn't called from portal_url but from current context url
