### PR TITLE
Missing translation on vocabulary elements.

### DIFF
--- a/plone/app/querystring/registryreader.py
+++ b/plone/app/querystring/registryreader.py
@@ -67,7 +67,13 @@ class QuerystringRegistryReader(object):
                 utility = getUtility(IVocabularyFactory, vocabulary)
                 for item in sorted(utility(self.context),
                                    key=attrgetter('title')):
-                    field['values'][item.value] = {'title': item.title}
+
+                    if isinstance(item.title, Message):
+                        title = translate(item.title, context=getRequest())
+                    else:
+                        title = item.title
+
+                    field['values'][item.value] = {'title': title}
         return values
 
     def mapOperations(self, values):


### PR DESCRIPTION
The translation machinery was not invoked on the elements returned by a vocabulary, this has been fixed in this pull request. 
