### PR TITLE
fixed test for _pathWithoutSubfolders function in queryparser.py

### DIFF
--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -310,7 +310,7 @@ class TestQueryGenerators(TestQueryParserBase):
             operator='_pathWithoutSubfolders',
             values='/news/'
         )
-        parsed = queryparser._path(MockSite(), data)
+        parsed = queryparser._pathWithoutSubfolders(MockSite(), data)
         expected = {'path': {'query': '/%s/news/' % MOCK_SITE_ID, 'depth': 1}}
         self.assertEqual(parsed, expected)
 


### PR DESCRIPTION
found a bug in a test for the last added "no subfolders" option and fixed it, test failes without this
