### PR TITLE
Fix UnicodeDecodeError on utf8-encoded Subject strings.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,8 @@ Changelog
 1.0.8 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix UnicodeDecodeError on utf8-encoded Subject strings.
+  [tisto]
 
 
 1.0.7 (2013-01-01)

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -75,6 +75,33 @@ class QueryBuilder(BrowserView):
         if 'path' not in parsedquery:
             parsedquery['path'] = {'query': ''}
 
+        # The Subject field in Plone currently uses a utf-8 encoded string.
+        # When a catalog query tries to compare a unicode string from the
+        # parsedquery with existing utf-8 encoded string indexes unindexing
+        # will fail with a UnicodeDecodeError. To prevent this from happening
+        # we always encode the Subject query.
+        # XXX: As soon as Plone uses unicode for all indexes, this code can
+        # be removed.
+        if 'Subject' in parsedquery:
+            query = parsedquery['Subject']['query']
+            # query can be a unicode string or a list of unicode strings.
+            if isinstance(query, unicode):
+                parsedquery['Subject']['query'] = query.encode("utf-8")
+            elif isinstance(query, list):
+                # We do not want to change the collections' own query string,
+                # therefore we create a new copy of the list.
+                copy_of_query = list(query)
+                # Iterate over all query items and encode them if they are
+                # unicode strings
+                i = 0
+                for item in copy_of_query:
+                    if isinstance(item, unicode):
+                        copy_of_query[i] = item.encode("utf-8")
+                    i += 1
+                parsedquery['Subject']['query'] = copy_of_query
+            else:
+                pass
+
         results = catalog(parsedquery)
         if not brains:
             results = IContentListing(results)


### PR DESCRIPTION
This addresses an issue that Timo fixed some time ago.

This pull request only contains the bugfix, without the additional "feature" of using plone.batching (https://github.com/plone/plone.app.querystring/pull/5).
