### PR TITLE
Logic fix

### DIFF
--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -57,8 +57,10 @@ class QueryBuilder(BrowserView):
                        sort_order=self.request.get('sort_order', None),
                        limit=10)
 
-        return getMultiAdapter((results, self.request),
-            name='display_query_results')(**options)
+        return getMultiAdapter(
+            (results, self.request),
+            name='display_query_results'
+        )(**options)
 
     def _makequery(self, query=None, batch=False, b_start=0, b_size=30,
                    sort_on=None, sort_order=None, limit=0, brains=False):
@@ -125,10 +127,12 @@ class QueryBuilder(BrowserView):
     def number_of_results(self, query):
         """Get the number of results"""
         results = self(query, sort_on=None, sort_order=None, limit=1)
-        return translate(_(u"batch_x_items_matching_your_criteria",
-                 default=u"${number} items matching your search terms.",
-                 mapping={'number': results.actual_result_count}),
-                 context=self.request)
+        return translate(
+            _(u"batch_x_items_matching_your_criteria",
+              default=u"${number} items matching your search terms.",
+              mapping={'number': results.actual_result_count}),
+            context=self.request
+        )
 
 
 class RegistryConfiguration(BrowserView):


### PR DESCRIPTION
The logic of how to handle limit and batch size was broken, i.e. the amount of actual elements shown in the batch and total batches were incorrect. This has been fixed in this pull request.

Further on some pep8 details has been corrected.

Tests are verified.
