### PR TITLE
Implement multipath queries.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,12 @@ Changelog
 1.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Implement multipath queries:
+  - Parsing a path returns always a list.
+  - Special handling for paths in parseFormquery.
+
+  Fixes https://dev.plone.org/ticket/13251
+  [mathias.leimgruber]
 
 
 1.1.1 (2014-01-27)

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -140,7 +140,8 @@ class TestQueryParser(TestQueryParserBase):
             'v': '/foo',
         }
         parsed = queryparser.parseFormquery(MockSite(), [data, ])
-        self.assertEqual(parsed, {'path': {'query': '/%s/foo' % MOCK_SITE_ID}})
+        self.assertEqual(
+            parsed, {'path': {'query': ['/%s/foo' % MOCK_SITE_ID]}})
 
     def test_path_computed(self):
         data = {
@@ -150,7 +151,8 @@ class TestQueryParser(TestQueryParserBase):
         }
 
         parsed = queryparser.parseFormquery(MockSite(), [data, ])
-        self.assertEqual(parsed, {'path': {'query': '/%s/foo' % MOCK_SITE_ID}})
+        self.assertEqual(
+            parsed, {'path': {'query': ['/%s/foo' % MOCK_SITE_ID]}})
 
     def test_path_with_depth_computed(self):
         data = {
@@ -162,10 +164,46 @@ class TestQueryParser(TestQueryParserBase):
         parsed = queryparser.parseFormquery(MockSite(), [data, ])
         self.assertEqual(parsed, {
             'path': {
-                'query': '/%s/foo' % MOCK_SITE_ID,
+                'query': ['/%s/foo' % MOCK_SITE_ID],
                 'depth': 2
             }
         })
+
+    def test_multi_path(self):
+        data_1 = {
+            'i': 'path',
+            'o': 'plone.app.querystring.operation.string.path',
+            'v': '/foo',
+        }
+        data_2 = {
+            'i': 'path',
+            'o': 'plone.app.querystring.operation.string.path',
+            'v': '/bar',
+        }
+
+        parsed = queryparser.parseFormquery(MockSite(), [data_1, data_2])
+        self.assertEqual(
+            parsed, {'path': {'query': [
+                '/%s/foo' % MOCK_SITE_ID,
+                '/%s/bar' % MOCK_SITE_ID]}})
+
+    def test_multi_path_with_depth_computet(self):
+        data_1 = {
+            'i': 'path',
+            'o': 'plone.app.querystring.operation.string.path',
+            'v': '/foo::2',
+        }
+        data_2 = {
+            'i': 'path',
+            'o': 'plone.app.querystring.operation.string.path',
+            'v': '/bar::5',
+        }
+
+        parsed = queryparser.parseFormquery(MockSite(), [data_1, data_2])
+        self.assertEqual(
+            parsed, {'path': {'query': [
+                '/%s/foo' % MOCK_SITE_ID,
+                '/%s/bar' % MOCK_SITE_ID], 'depth': 2}})
 
 
 class TestQueryGenerators(TestQueryParserBase):


### PR DESCRIPTION
This PR implements multipath query for collections.

Fixes https://dev.plone.org/ticket/13251

I know that @tisto implemented something similar in https://github.com/plone/plone.app.querystring/pull/10.

But imho it's better to have multiple path criterions (multiple input fields), than entering a list in one single input field. This is more readable for the user and we don't have to change/improve the widget. 

Before:
Searches only in the second path `/news`. Means only one result.

![screen shot 2014-01-29 at 11 17 54 am](https://f.cloud.github.com/assets/437933/2028442/a8985118-88ce-11e3-9475-7abcfcd51ec1.png)

After: 
Multipath query for `/events` and `/news`. Shows both items.

![screen shot 2014-01-29 at 11 13 14 am](https://f.cloud.github.com/assets/437933/2028413/0b772a8a-88ce-11e3-9a84-75754ee37602.png)
