### PR TITLE
Add operators selection.any and selection.all to Subject

### DIFF
--- a/plone/app/querystring/profiles.zcml
+++ b/plone/app/querystring/profiles.zcml
@@ -27,4 +27,12 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:registerProfile
+        name="upgrade_to_6"
+        title="Querystring Upgrade profile to v6"
+        description=""
+        directory="profiles/upgrades/to_6"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
  </configure>

--- a/plone/app/querystring/profiles.zcml
+++ b/plone/app/querystring/profiles.zcml
@@ -35,4 +35,20 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:registerProfile
+        name="upgrade_to_7"
+        title="Querystring Upgrade profile to v7"
+        description=""
+        directory="profiles/upgrades/to_7"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        name="upgrade_to_8"
+        title="Querystring Upgrade profile to v8"
+        description=""
+        directory="profiles/upgrades/to_8"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
  </configure>

--- a/plone/app/querystring/profiles/default/registry.xml
+++ b/plone/app/querystring/profiles/default/registry.xml
@@ -202,6 +202,22 @@
         <value key="widget">RelativePathWidget</value>
     </records>
 
+    <records interface="plone.app.querystring.interfaces.IQueryOperation"
+             prefix="plone.app.querystring.operation.selection.oneOf">
+        <value key="title" i18n:translate="">Contains one of</value>
+        <value key="description" i18n:translate="">Tip: you can use * to autocomplete.</value>
+        <value key="operation">plone.app.querystring.queryparser._contains</value>
+        <value key="widget">MultipleSelectionWidget</value>
+    </records>
+
+    <records interface="plone.app.querystring.interfaces.IQueryOperation"
+             prefix="plone.app.querystring.operation.selection.all">
+        <value key="title" i18n:translate="">Contains all</value>
+        <value key="description" i18n:translate="">Tip: you can use * to autocomplete.</value>
+        <value key="operation">plone.app.querystring.queryparser._all</value>
+        <value key="widget">MultipleSelectionWidget</value>
+    </records>
+
 <!-- QueryField declarations  -->
     <records interface="plone.app.querystring.interfaces.IQueryField"
              prefix="plone.app.querystring.field.path">
@@ -502,7 +518,8 @@
         <value key="enabled">True</value>
         <value key="sortable">True</value>
         <value key="operations">
-            <element>plone.app.querystring.operation.selection.is</element>
+            <element>plone.app.querystring.operation.selection.oneOf</element>
+            <element>plone.app.querystring.operation.selection.all</element>
         </value>
        <value key="vocabulary">plone.app.vocabularies.Keywords</value>
        <value key="group" i18n:translate="">Text</value>

--- a/plone/app/querystring/profiles/default/registry.xml
+++ b/plone/app/querystring/profiles/default/registry.xml
@@ -526,7 +526,7 @@
         <value key="enabled">True</value>
         <value key="sortable">True</value>
         <value key="operations">
-            <element>plone.app.querystring.operation.selection.oneOf</element>
+            <element>plone.app.querystring.operation.selection.any</element>
             <element>plone.app.querystring.operation.selection.all</element>
         </value>
        <value key="vocabulary">plone.app.vocabularies.Keywords</value>

--- a/plone/app/querystring/profiles/upgrades/to_6/registry.xml
+++ b/plone/app/querystring/profiles/upgrades/to_6/registry.xml
@@ -1,0 +1,35 @@
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone">
+
+    <records interface="plone.app.querystring.interfaces.IQueryOperation"
+             prefix="plone.app.querystring.operation.selection.oneOf">
+        <value key="title" i18n:translate="">Contains one of</value>
+        <value key="description" i18n:translate="">Tip: you can use * to autocomplete.</value>
+        <value key="operation">plone.app.querystring.queryparser._contains</value>
+        <value key="widget">MultipleSelectionWidget</value>
+    </records>
+
+    <records interface="plone.app.querystring.interfaces.IQueryOperation"
+             prefix="plone.app.querystring.operation.selection.all">
+        <value key="title" i18n:translate="">Contains all</value>
+        <value key="description" i18n:translate="">Tip: you can use * to autocomplete.</value>
+        <value key="operation">plone.app.querystring.queryparser._all</value>
+        <value key="widget">MultipleSelectionWidget</value>
+    </records>
+
+    <records interface="plone.app.querystring.interfaces.IQueryField"
+             prefix="plone.app.querystring.field.Subject">
+        <value key="title" i18n:translate="">Tag</value>
+        <value key="description" i18n:translate="">Tags are used for organization of content</value>
+        <value key="enabled">True</value>
+        <value key="sortable">True</value>
+        <value key="operations">
+            <element>plone.app.querystring.operation.selection.oneOf</element>
+            <element>plone.app.querystring.operation.selection.all</element>
+        </value>
+       <value key="vocabulary">plone.app.vocabularies.Keywords</value>
+       <value key="group" i18n:translate="">Text</value>
+    </records>
+
+
+</registry>

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -65,6 +65,10 @@ def _equal(context, row):
     return {row.index: {'query': row.values, }}
 
 
+def _all(context, row):
+    return {row.index: {'query': row.values, 'operator': 'and'}}
+
+
 def _isTrue(context, row):
     return {row.index: {'query': True, }}
 

--- a/plone/app/querystring/upgrades.zcml
+++ b/plone/app/querystring/upgrades.zcml
@@ -41,4 +41,13 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      source="5"
+      destination="6"
+      profile="plone.app.querystring:default">
+    <genericsetup:upgradeDepends
+        title="Change subject operations to selection.oneOf and selection.all"
+        import_profile="plone.app.querystring:upgrade_to_6"
+        />
+  </genericsetup:upgradeSteps>
 </configure>


### PR DESCRIPTION
change Subject QueryField operators to use selection.oneOf and selection.all
operators. The change make's it possible to use "oneOf" (OR) and "all" (AND) for
Tag criteria of collections. Now is there only a meaningless "Is" operator.