### PR TITLE
Fix getObjPositionInParent be sortable

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.2 (unreleased)
 ------------------
 
+- Fix getObjPositionInParent be sortable by default
+  [datakurre]
+
 - Implement ``is``, ``lessThan`` and ``largerThan`` operators for integer fields (fixes `#32`_).
   [rodfersou]
 

--- a/plone/app/querystring/profiles.zcml
+++ b/plone/app/querystring/profiles.zcml
@@ -27,12 +27,19 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
-
     <genericsetup:registerProfile
         name="upgrade_to_6"
         title="Querystring Upgrade profile to v6"
         description=""
         directory="profiles/upgrades/to_6"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
+    <genericsetup:registerProfile
+        name="upgrade_to_7"
+        title="Querystring Upgrade profile to v7"
+        description=""
+        directory="profiles/upgrades/to_7"
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 

--- a/plone/app/querystring/profiles/default/metadata.xml
+++ b/plone/app/querystring/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>6</version>
+  <version>7</version>
   <dependencies>
       <dependency>profile-plone.app.registry:default</dependency>
   </dependencies>

--- a/plone/app/querystring/profiles/default/registry.xml
+++ b/plone/app/querystring/profiles/default/registry.xml
@@ -335,7 +335,7 @@
         <value key="title" i18n:translate="">Order in folder</value>
         <value key="description" i18n:translate="">The order of an item in its parent folder</value>
         <value key="enabled">False</value>
-        <value key="sortable">False</value>
+        <value key="sortable">True</value>
         <value key="operations">
             <element>plone.app.querystring.operation.int.is</element>
             <element>plone.app.querystring.operation.int.lessThan</element>

--- a/plone/app/querystring/profiles/upgrades/to_7/registry.xml
+++ b/plone/app/querystring/profiles/upgrades/to_7/registry.xml
@@ -1,0 +1,9 @@
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone">
+
+    <records interface="plone.app.querystring.interfaces.IQueryField"
+             prefix="plone.app.querystring.field.getObjPositionInParent">
+        <value key="sortable">True</value>
+    </records>
+
+</registry>

--- a/plone/app/querystring/upgrades.zcml
+++ b/plone/app/querystring/upgrades.zcml
@@ -51,4 +51,14 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      source="6"
+      destination="7"
+      profile="plone.app.querystring:default">
+    <genericsetup:upgradeDepends
+        title="Fix getObjPositionInParent be sortable by default"
+        import_profile="plone.app.querystring:upgrade_to_7"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>


### PR DESCRIPTION
Any reason, why sorting by getObjPositionInParent has not been enabled by default?