### PR TITLE
Collections fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Do not fail if the 'Between' operation is called with an empty value, and
+  instead return a list with 2 empty values.
+  [frapell]
+
 - Fixed possible problem with ``custom_query`` parameter where
   theoretically a second invocation could inadvertently be using the
   value from the first invocation.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Use selection.all for portal_types, review_state and Creator operations.
+  [frapell]
+
 - Actually convert the value to a datetime for the DateIndex query modifier.
   [frapell]
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.3.4 (unreleased)
 ------------------
 
+- Actually convert the value to a datetime for the DateIndex query modifier.
+  [frapell]
+
 - Do not fail if the 'Between' operation is called with an empty value, and
   instead return a list with 2 empty values.
   [frapell]

--- a/plone/app/querystring/indexmodifiers/query_index_modifiers.py
+++ b/plone/app/querystring/indexmodifiers/query_index_modifiers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf8 -*-
+from datetime import datetime
 from plone.app.querystring.interfaces import IParsedQueryIndexModifier
 from zope.interface import implements
 
@@ -54,11 +55,24 @@ class base(object):
         query = value['query']
         if isinstance(query, unicode):
             query = query.encode("utf-8")
+
+        if isinstance(query, basestring):
+            try:
+                query = datetime.strptime(query, "%Y-%m-%d")
+            except:
+                query = query.encode("utf-8")
         elif isinstance(query, list):
-            query = [
-                item.encode("utf-8") if isinstance(item, unicode) else item
-                for item in query
-            ]
+            aux = list()
+            for item in query:
+                if isinstance(item, unicode):
+                    item = item.encode("utf-8")
+                try:
+                    val = datetime.strptime(item, "%Y-%m-%d")
+                except:
+                    val = item
+                aux.append(val)
+
+            query = aux
         else:
             pass
         value['query'] = query

--- a/plone/app/querystring/profiles.zcml
+++ b/plone/app/querystring/profiles.zcml
@@ -51,4 +51,12 @@
         provides="Products.GenericSetup.interfaces.EXTENSION"
         />
 
+    <genericsetup:registerProfile
+        name="upgrade_to_9"
+        title="Querystring Upgrade profile to v9"
+        description=""
+        directory="profiles/upgrades/to_9"
+        provides="Products.GenericSetup.interfaces.EXTENSION"
+        />
+
  </configure>

--- a/plone/app/querystring/profiles/default/metadata.xml
+++ b/plone/app/querystring/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>7</version>
+  <version>9</version>
   <dependencies>
       <dependency>profile-plone.app.registry:default</dependency>
   </dependencies>

--- a/plone/app/querystring/profiles/default/registry.xml
+++ b/plone/app/querystring/profiles/default/registry.xml
@@ -280,6 +280,7 @@
         <value key="sortable">True</value>
         <value key="operations">
             <element>plone.app.querystring.operation.string.is</element>
+            <element>plone.app.querystring.operation.selection.any</element>
             <element>plone.app.querystring.operation.string.currentUser</element>
         </value>
        <value key="group" i18n:translate="">Metadata</value>
@@ -443,7 +444,7 @@
         <value key="enabled">True</value>
         <value key="sortable">False</value>
         <value key="operations">
-            <element>plone.app.querystring.operation.selection.is</element>
+            <element>plone.app.querystring.operation.selection.any</element>
         </value>
         <value key="vocabulary">plone.app.vocabularies.ReallyUserFriendlyTypes</value>
        <value key="group" i18n:translate="">Metadata</value>
@@ -469,7 +470,7 @@
         <value key="enabled">True</value>
         <value key="sortable">True</value>
         <value key="operations">
-            <element>plone.app.querystring.operation.selection.is</element>
+            <element>plone.app.querystring.operation.selection.any</element>
         </value>
         <value key="vocabulary">plone.app.vocabularies.WorkflowStates</value>
        <value key="group" i18n:translate="">Metadata</value>

--- a/plone/app/querystring/profiles/upgrades/to_9/registry.xml
+++ b/plone/app/querystring/profiles/upgrades/to_9/registry.xml
@@ -1,0 +1,44 @@
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone">
+
+    <records interface="plone.app.querystring.interfaces.IQueryField"
+             prefix="plone.app.querystring.field.portal_type">
+        <value key="title" i18n:translate="">Type</value>
+        <value key="description" i18n:translate="">An item's type (e.g. Event)</value>
+        <value key="enabled">True</value>
+        <value key="sortable">False</value>
+        <value key="operations">
+            <element>plone.app.querystring.operation.selection.any</element>
+        </value>
+        <value key="vocabulary">plone.app.vocabularies.ReallyUserFriendlyTypes</value>
+       <value key="group" i18n:translate="">Metadata</value>
+    </records>
+
+    <records interface="plone.app.querystring.interfaces.IQueryField"
+             prefix="plone.app.querystring.field.review_state">
+        <value key="title" i18n:translate="">Review state</value>
+        <value key="description" i18n:translate="">An item's workflow state (e.g.published)</value>
+        <value key="enabled">True</value>
+        <value key="sortable">True</value>
+        <value key="operations">
+            <element>plone.app.querystring.operation.selection.any</element>
+        </value>
+        <value key="vocabulary">plone.app.vocabularies.WorkflowStates</value>
+       <value key="group" i18n:translate="">Metadata</value>
+    </records>
+
+    <records interface="plone.app.querystring.interfaces.IQueryField"
+             prefix="plone.app.querystring.field.Creator">
+        <value key="title" i18n:translate="">Creator</value>
+        <value key="description" i18n:translate="">The person that created an item</value>
+        <value key="enabled">True</value>
+        <value key="sortable">True</value>
+        <value key="operations">
+            <element>plone.app.querystring.operation.string.is</element>
+            <element>plone.app.querystring.operation.selection.any</element>
+            <element>plone.app.querystring.operation.string.currentUser</element>
+        </value>
+       <value key="group" i18n:translate="">Metadata</value>
+    </records>
+
+</registry>

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -86,9 +86,14 @@ def _isFalse(context, row):
 
 
 def _between(context, row):
+    if not row.values:
+        val = ['', '']
+    else:
+        val = row.values
+
     tmp = {row.index:
            {
-               'query': sorted(row.values),
+               'query': sorted(val),
                'range': 'minmax',
            },
            }

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -244,6 +244,17 @@ class TestQueryGenerators(TestQueryParserBase):
                     'range': 'minmax'}}
         self.assertEqual(parsed, expected)
 
+    def test__between_empty_input(self):
+        data = Row(
+            index='modified',
+            operator='_between',
+            values=''
+        )
+        parsed = queryparser._between(MockSite(), data)
+        expected = {'modified': {'query': ['', ''],
+                    'range': 'minmax'}}
+        self.assertEqual(parsed, expected)
+
     def test__equal(self):
         data = Row(
             index='modified',

--- a/plone/app/querystring/upgrades.zcml
+++ b/plone/app/querystring/upgrades.zcml
@@ -71,4 +71,14 @@
         />
   </genericsetup:upgradeSteps>
 
+  <genericsetup:upgradeSteps
+      source="8"
+      destination="9"
+      profile="plone.app.querystring:default">
+    <genericsetup:upgradeDepends
+        title="Change portal_types, review_state and Creator operations to use selection.all"
+        import_profile="plone.app.querystring:upgrade_to_9"
+        />
+  </genericsetup:upgradeSteps>
+
 </configure>


### PR DESCRIPTION
This PR fixes 2 issues currently present with collections:

1) When choosing the "Between dates" operation, there is a first call with empty values that throws an error

2) When a collection has a date stored for a query, the index modifier left it as a string, causing the catalog query to not work properly. This converts the string to a proper datetime for searches.