### PR TITLE
fix: set path to navigation root by default

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ New:
 
 Fixes:
 
-- *add item here*
+- Set path to navigation root by default to have the same results
+  in Collection preview and view.
+  [Gagaro]
 
 
 1.3.13 (2016-02-14)

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -105,6 +105,20 @@ class QueryBuilder(BrowserView):
                    sort_on=None, sort_order=None, limit=0, brains=False,
                    custom_query=None):
         """Parse the (form)query and return using multi-adapter"""
+        # Reproduce path behaviours of Collection
+        # See p.a.contenttypes.behaviours.collection.Collection
+        if query:
+            has_path_criteria = any(
+                (criteria['i'] == 'path')
+                for criteria in query
+            )
+            if not has_path_criteria:
+                query.append({
+                    'i': 'path',
+                    'o': 'plone.app.querystring.operation.string.path',
+                    'v': '/',
+                })
+
         parsedquery = queryparser.parseFormquery(
             self.context, query, sort_on, sort_order)
 


### PR DESCRIPTION
The preview results of a collection are not the same as the real one when the path is not set. This fixes it.