### PR TITLE
Introduce IQueryModifier, refactor INavigationRoot stickyness.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-1.3.16 (unreleased)
--------------------
+1.4.0 (unreleased)
+------------------
 
 Breaking changes:
 
@@ -10,7 +10,11 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Refactor addition of criteria to stick inside ``INavigationRoot`` in querybuilder.
+  Added a simple ``IQueryModifier`` interfaces expecting a query and returning a query.
+  Iterates over all sorted utilities providing such an interfaces and calls it right before the query is parsed.
+  Code to add the ``INavigationRoot`` stickyness was moved to such a query modifier.
+  [jensens]
 
 Bug fixes:
 

--- a/plone/app/querystring/configure.zcml
+++ b/plone/app/querystring/configure.zcml
@@ -59,5 +59,8 @@
     permission="zope2.View"
     for="*"
     />
-
+  <utility
+    component=".querymodifiers.modify_query_to_enforce_navigation_root"
+    name="1000"
+    />
 </configure>

--- a/plone/app/querystring/interfaces.py
+++ b/plone/app/querystring/interfaces.py
@@ -43,3 +43,13 @@ class IParsedQueryIndexModifier(Interface):
         if the index name returned is different from the native one, caller
         must replace treated index with the new ones.
         """
+
+
+class IQueryModifier(Interface):
+    """Modifies a query in order to inject specific or change given criteria.
+    """
+
+    def __call__(query):
+        """
+        modify the query and return an new one.
+        """

--- a/plone/app/querystring/querymodifiers.py
+++ b/plone/app/querystring/querymodifiers.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from plone.app.querystring.interfaces import IQueryModifier
+from zope.interface import provider
+
+
+@provider(IQueryModifier)
+def modify_query_to_enforce_navigation_root(query):
+    """enforce a search in the current navigation root
+
+    if not already a path was given we search only for contents in the current
+    IVavigationRoot.
+    """
+    if not query:
+        return query
+
+    has_path_criteria = any(
+        (criteria['i'] == 'path')
+        for criteria in query
+    )
+    if not has_path_criteria:
+        query = list(query)
+        query.append({
+            'i': 'path',
+            'o': 'plone.app.querystring.operation.string.path',
+            'v': '/',
+        })
+    return query

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-version = '1.3.16.dev0'
+version = '1.4.0.dev0'
 
 long_description = open("README.rst").read() + "\n"
 long_description += open("CHANGES.rst").read()


### PR DESCRIPTION
Refactor addition of criteria to stick inside ``INavigationRoot`` in querybuilder.
Added a simple ``IQueryModifier`` interfaces expecting a query and returning a query.
Iterates over all sorted utilities providing such an interfaces and calls it right before the query is parsed.
Code to add the ``INavigationRoot`` stickyness was moved to such a query modifier.
