### PR TITLE
Change *Show Inactive* criteria to check against local roles instead of global roles

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,7 +10,9 @@ Breaking changes:
 
 New features:
 
-- *add item here*
+- Change *Show Inactive* criteria to check against user context local
+  roles (usually global roles by default) instead of only global roles
+  [datakurre]
 
 Bug fixes:
 

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -162,7 +162,7 @@ def _showInactive(context, row):
     mt = getToolByName(context, 'portal_membership')
     user = mt.getAuthenticatedMember()
     value = False
-    user_roles = user.getRoles()
+    user_roles = user.getRolesInContext(context)
     row_values = row.values
     if row_values:
         for role in user_roles:

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -104,7 +104,7 @@ class MockUser(object):
     def getUserName(self):
         return self.username
 
-    def getRoles(self):
+    def getRolesInContext(self, context):
         return self.roles
 
 


### PR DESCRIPTION
@ichim-david @jensens You were active, when this feature was first implemented in https://github.com/plone/plone.app.querystring/pull/20 

Any reason, why we should not use local roles instead of global roles?