### PR TITLE
RelativeDate index modifier fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Fix a case, where index modifiers with queries containing ``largerThanRelativeDate`` or ``lessThanRelativeDate`` date operators failed with an ``TypeError``.
+  [thet]
 
 
 1.4.1 (2016-11-18)

--- a/plone/app/querystring/indexmodifiers/query_index_modifiers.py
+++ b/plone/app/querystring/indexmodifiers/query_index_modifiers.py
@@ -43,36 +43,35 @@ class Subject(object):
 
 @implementer(IParsedQueryIndexModifier)
 class base(object):
-
-    """
-    DateIndex query modifier
+    """DateIndex query modifier
     see Products.PluginIndexes.DateIndex.DateIndex.DateIndex._convert function
     """
 
     def __call__(self, value):
-        query = value['query']
-        if isinstance(query, unicode):
-            query = query.encode("utf-8")
 
-        if isinstance(query, basestring):
-            try:
-                query = parse(query)
-            except (ValueError, AttributeError):
-                query = query.encode("utf-8")
-        elif isinstance(query, list):
+        def _normalize(val):
+            """Encode value, parse dates.
+            """
+            if isinstance(val, unicode):
+                val = val.encode("utf-8")
+
+            if isinstance(val, basestring):
+                try:
+                    val = parse(val)
+                except (ValueError, AttributeError):
+                    pass
+
+            return val
+
+        query = value['query']
+        query = _normalize(query)
+
+        if isinstance(query, list):
             aux = list()
             for item in query:
-                if isinstance(item, unicode):
-                    item = item.encode("utf-8")
-                try:
-                    val = parse(item)
-                except (ValueError, AttributeError):
-                    val = item
-                aux.append(val)
-
+                aux.append(_normalize(item))
             query = aux
-        else:
-            pass
+
         value['query'] = query
         return (self.__class__.__name__, value)
 

--- a/plone/app/querystring/tests/testIndexmodifiers.py
+++ b/plone/app/querystring/tests/testIndexmodifiers.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from DateTime import DateTime
 from datetime import datetime
 from plone.app.querystring.indexmodifiers import query_index_modifiers
 
@@ -26,6 +27,34 @@ class TestIndexModifiers(unittest.TestCase):
         query = {'query': ['01/01/2010', '01/01/2010']}
         self.assertTrue(
             isinstance(modifier(query)[1]['query'][0], datetime)
+        )
+
+    def test_date_modifier_list_DateTime(self):
+        """Test a case with largerThanRelativeDate operatiors, where
+        plone.app.querystring.querybuilder parses a querystring like this one:
+        >>> query
+        [{
+            u'i': u'end',
+            u'o': u'plone.app.querystring.operation.date.largerThanRelativeDate',  # noqa
+            u'v': u'30'
+        }]
+
+        into something like this:
+        >>> parsedquery
+        {
+            u'end': {
+                'query': [
+                    DateTime('2016/12/10 00:00:00 US/Central'),
+                    DateTime('2017/01/09 23:59:59 US/Central')
+                ],
+                'range': 'minmax'
+            },
+        }
+        """
+        modifier = query_index_modifiers.start()
+        query = {'query': [DateTime('01/01/2010'), DateTime('01/01/2010')]}
+        self.assertTrue(
+            isinstance(modifier(query)[1]['query'][0], DateTime)
         )
 
     def test_invalid_date(self):


### PR DESCRIPTION
Fix a case, where index modifiers with queries containing ``largerThanRelativeDate`` or ``lessThanRelativeDate`` date operators failed with an ``TypeError``.