### PR TITLE
Make integer query operators accept unicode values.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,9 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Make integer query operators accept unicode values
+  Fixes their usage via QueryStringFieldWidget
+  [lzdych]
 
 
 1.3.16 (2017-01-17)

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -75,7 +75,7 @@ def _intEqual(context, row):
     values = None
     if type(row.values) is list:
         values = [int(v) for v in row.values]
-    elif type(row.values) is str:
+    elif type(row.values) in (str, unicode):
         values = int(row.values)
     return {row.index: {'query': values, }}
 
@@ -115,7 +115,7 @@ def _largerThan(context, row):
 
 def _intLargerThan(context, row):
     value = None
-    if type(row.values) is str:
+    if type(row.values) in (str, unicode):
         value = int(row.values)
     tmp = {row.index:
            {
@@ -138,7 +138,7 @@ def _lessThan(context, row):
 
 def _intLessThan(context, row):
     value = None
-    if type(row.values) is str:
+    if type(row.values) in (str, unicode):
         value = int(row.values)
     tmp = {row.index:
            {

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -288,6 +288,15 @@ class TestQueryGenerators(TestQueryParserBase):
         data = Row(
             index='modified',
             operator='_intEqual',
+            values=u'20'
+        )
+        parsed = queryparser._intEqual(MockSite(), data)
+        expected = {'modified': {'query': 20}}
+        self.assertEqual(parsed, expected)
+
+        data = Row(
+            index='modified',
+            operator='_intEqual',
             values=['20', '21']
         )
         parsed = queryparser._intEqual(MockSite(), data)
@@ -314,6 +323,15 @@ class TestQueryGenerators(TestQueryParserBase):
         expected = {'modified': {'query': 20, 'range': 'max'}}
         self.assertEqual(parsed, expected)
 
+        data = Row(
+            index='modified',
+            operator='_intLessThan',
+            values=u'20'
+        )
+        parsed = queryparser._intLessThan(MockSite(), data)
+        expected = {'modified': {'query': 20, 'range': 'max'}}
+        self.assertEqual(parsed, expected)
+
     def test__largerThan(self):
         data = Row(
             index='modified',
@@ -329,6 +347,15 @@ class TestQueryGenerators(TestQueryParserBase):
             index='modified',
             operator='_intLargerThan',
             values='20'
+        )
+        parsed = queryparser._intLargerThan(MockSite(), data)
+        expected = {'modified': {'query': 20, 'range': 'min'}}
+        self.assertEqual(parsed, expected)
+
+        data = Row(
+            index='modified',
+            operator='_intLargerThan',
+            values=u'20'
         )
         parsed = queryparser._intLargerThan(MockSite(), data)
         expected = {'modified': {'query': 20, 'range': 'min'}}


### PR DESCRIPTION
Fixes their usage via QueryStringFieldWidget.