### PR TITLE
Fix QueryBuilder with empty queries to return a Batch when requested.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Fix ``QueryBuilder`` with empty queries to return a Batch when requested.
+  [thet]
+
 - Disable "Subject" ("Tags") as sortable index.
   Keyword Indexes are not sortable.
   [jensens]
@@ -286,7 +289,7 @@ Fixes:
   [sdelcourt]
 
 - Fix querybuilder code if results object does not provide an
-  actual_results_count attribute. This regression has been introduced in
+  actual_result_count attribute. This regression has been introduced in
   release 1.1.1 (fixed broken handling of limit and batch size).
   [timo]
 

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -135,11 +135,7 @@ class QueryBuilder(BrowserView):
                 "Using empty query because there are no valid indexes used.")
             parsedquery = {}
 
-        if not parsedquery:
-            if brains:
-                return []
-            else:
-                return IContentListing([])
+        empty_query = not parsedquery  # store emptiness
 
         if batch:
             parsedquery['b_start'] = b_start
@@ -150,16 +146,19 @@ class QueryBuilder(BrowserView):
         if 'path' not in parsedquery:
             parsedquery['path'] = {'query': ''}
 
-        if isinstance(custom_query, dict):
+        if isinstance(custom_query, dict) and custom_query:
             # Update the parsed query with an extra query dictionary. This may
             # override the parsed query. The custom_query is a dictonary of
             # index names and their associated query values.
             parsedquery.update(custom_query)
+            empty_query = False
 
-        results = catalog(**parsedquery)
-        if getattr(results, 'actual_result_count', False) and limit\
-                and results.actual_result_count > limit:
-            results.actual_result_count = limit
+        results = []
+        if not empty_query:
+            results = catalog(**parsedquery)
+            if getattr(results, 'actual_result_count', False) and limit\
+                    and results.actual_result_count > limit:
+                results.actual_result_count = limit
 
         if not brains:
             results = IContentListing(results)

--- a/plone/app/querystring/tests/testQueryBuilder.py
+++ b/plone/app/querystring/tests/testQueryBuilder.py
@@ -189,6 +189,62 @@ class TestQuerybuilder(unittest.TestCase):
         self.assertEqual(results[0].Title(), 'Test Folder')
 
 
+class TestQuerybuilderResultTypes(unittest.TestCase):
+
+    layer = TEST_PROFILE_PLONEAPPQUERYSTRING_INTEGRATION_TESTING
+
+    def setUp(self):
+        self.portal = self.layer['portal']
+        self.request = TestRequest()
+        self.querybuilder = getMultiAdapter(
+            (self.portal, self.request),
+            name='querybuilderresults'
+        )
+        self.query = [{
+            'i': 'Title',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': 'Non-existent',
+        }]
+
+    def testQueryBuilderEmptyQueryContentListing(self):
+        results = self.querybuilder(query={})
+        self.assertEqual(len(results), 0)
+        self.assertEqual(type(results).__name__, 'ContentListing')
+
+    def testQueryBuilderEmptyQueryBrains(self):
+        results = self.querybuilder(query={}, brains=True)
+        self.assertEqual(len(results), 0)
+        self.assertEqual(results, [])
+
+    def testQueryBuilderEmptyQueryBatch(self):
+        results = self.querybuilder(query={}, batch=True)
+        self.assertEqual(len(results), 0)
+        self.assertEqual(type(results).__name__, 'BaseBatch')
+
+    def testQueryBuilderNonEmptyQueryContentListing(self):
+        results = self.querybuilder(query=self.query)
+        self.assertEqual(len(results), 0)
+        self.assertEqual(type(results).__name__, 'ContentListing')
+
+    def testQueryBuilderNonEmptyQueryBrains(self):
+        results = self.querybuilder(query=self.query, brains=True)
+        self.assertEqual(len(results), 0)
+        self.assertEqual(type(results).__name__, 'LazyCat')
+
+    def testQueryBuilderNonEmptyQueryBatch(self):
+        results = self.querybuilder(query=self.query, batch=True)
+        self.assertEqual(len(results), 0)
+        self.assertEqual(type(results).__name__, 'BaseBatch')
+
+    def testQueryBuilderNonEmptyContentListingCustomQuery(self):
+        results = self.querybuilder(
+            query={},
+            custom_query={'portal_type': 'NonExistent'}
+        )
+        self.assertEqual(len(results), 0)
+        self.assertEqual(type(results).__name__, 'ContentListing')
+
+
 class TestConfigurationFetcher(unittest.TestCase):
 
     layer = TEST_PROFILE_PLONEAPPQUERYSTRING_INTEGRATION_TESTING


### PR DESCRIPTION
To fullfill the API when a Batch object was expected. E.g. it broke with empty queries when trying to access batch.length