### PR TITLE
Filter query string from bad term and operator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,7 @@ New features:
 
 Bug fixes:
 
-- Filter query string from bad term and operator
+- Filter query string from bad term and operator.
   [nngu6036]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Filter query string from bad term and operator
+  [nngu6036]
 
 
 1.4.5 (2017-06-20)


### PR DESCRIPTION
When submitting search query like  "<text-value> AND", the system throws Exception "ParseError: Token 'ATOM' required, 'EOF' found". The code fix exception by removing bad term and operator from search query.