### PR TITLE
Ignore unknown `sort_on` indexes when parsing a query. [1.2.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Ignore unknown ``sort_on`` indexes when parsing a query.
+  Otherwise you get a ``CatalogError``.  [maurits]
 
 
 1.2.11 (2017-01-17)

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -49,9 +49,12 @@ def parseFormquery(context, formquery, sort_on=None, sort_order=None):
 
     # Add sorting (sort_on and sort_order) to the query
     if sort_on:
-        query['sort_on'] = sort_on
-    if sort_order:
-        query['sort_order'] = sort_order
+        catalog = getToolByName(context, 'portal_catalog')
+        # I get crazy sort_ons like '194' or 'null'.
+        if sort_on in catalog.indexes():
+            query['sort_on'] = sort_on
+            if sort_order:
+                query['sort_order'] = sort_order
     return query
 
 

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -144,6 +144,34 @@ class TestQueryParser(TestQueryParserBase):
         parsed = queryparser.parseFormquery(MockSite(), [data, ])
         self.assertEqual(parsed, {'Title': {'query': 'Welcome to Plone'}})
 
+    def test_sort_on_known(self):
+        data = {
+            'i': 'Title',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': 'Welcome to Plone',
+        }
+        parsed = queryparser.parseFormquery(
+            MockSite(), [data, ],
+            sort_on='sortable_title',
+            sort_order='reverse')
+        self.assertEqual(
+            parsed, {'Title': {'query': 'Welcome to Plone'},
+                     'sort_on': 'sortable_title',
+                     'sort_order': 'reverse'})
+
+    def test_sort_on_unknown(self):
+        data = {
+            'i': 'Title',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': 'Welcome to Plone',
+        }
+        parsed = queryparser.parseFormquery(
+            MockSite(), [data, ],
+            sort_on='unknown',
+            sort_order='reverse')
+        self.assertEqual(
+            parsed, {'Title': {'query': 'Welcome to Plone'}})
+
     def test_path_explicit(self):
         data = {
             'i': 'path',


### PR DESCRIPTION
Otherwise you get a `CatalogError`.

This can happen when you are adding a Collection and there is no sort index selected yet. The javascript then queries for `sort_on=null`:
`http://127.0.0.1:8080/Plone/portal_factory/@@querybuilder_html_results?query.i:records=review_state&query.o:records=plone.app.querystring.operation.selection.is&query.v:records:list=published&sort_on=null`
This is on Plone 4.3, and might need plone.app.contenttypes. At least, I found this on a site with plone.app.contenttypes, and did not see it on a site with plone.app.collection, but maybe there is something specific for that site in play.

Sample traceback:
```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module plone.app.querystring.querybuilder, line 62, in html_results
  Module plone.app.querystring.querybuilder, line 53, in __call__
  Module plone.app.querystring.querybuilder, line 119, in _makequery
  Module collective.indexing.monkey, line 84, in searchResults
  Module Products.CMFPlone.CatalogTool, line 389, in searchResults
  Module Products.ZCatalog.ZCatalog, line 604, in searchResults
  Module Products.ZCatalog.Catalog, line 916, in searchResults
  Module Products.ZCatalog.Catalog, line 889, in _getSortIndex
CatalogError: Unknown sort_on index (null)
```

This could also be fixed by merging https://github.com/plone/Products.CMFPlone/pull/2286, as `searchResults` is in the traceback above, but it may be better to fix it here as well.