### PR TITLE
Ignore unknown `sort_on` indexes when parsing a query. [1.3.x]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,7 +14,8 @@ New features:
 
 Bug fixes:
 
-- *add item here*
+- Ignore unknown ``sort_on`` indexes when parsing a query.
+  Otherwise you get a ``CatalogError``.  [maurits]
 
 
 1.3.17 (2017-02-05)

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -51,9 +51,12 @@ def parseFormquery(context, formquery, sort_on=None, sort_order=None):
 
     # Add sorting (sort_on and sort_order) to the query
     if sort_on:
-        query['sort_on'] = sort_on
-    if sort_order:
-        query['sort_order'] = sort_order
+        catalog = getToolByName(context, 'portal_catalog')
+        # I get crazy sort_ons like '194' or 'null'.
+        if sort_on in catalog.indexes():
+            query['sort_on'] = sort_on
+            if sort_order:
+                query['sort_order'] = sort_order
     return query
 
 

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -149,6 +149,34 @@ class TestQueryParser(TestQueryParserBase):
         parsed = queryparser.parseFormquery(MockSite(), [data, ])
         self.assertEqual(parsed, {'Title': {'query': 'Welcome to Plone'}})
 
+    def test_sort_on_known(self):
+        data = {
+            'i': 'Title',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': 'Welcome to Plone',
+        }
+        parsed = queryparser.parseFormquery(
+            MockSite(), [data, ],
+            sort_on='sortable_title',
+            sort_order='reverse')
+        self.assertEqual(
+            parsed, {'Title': {'query': 'Welcome to Plone'},
+                     'sort_on': 'sortable_title',
+                     'sort_order': 'reverse'})
+
+    def test_sort_on_unknown(self):
+        data = {
+            'i': 'Title',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': 'Welcome to Plone',
+        }
+        parsed = queryparser.parseFormquery(
+            MockSite(), [data, ],
+            sort_on='unknown',
+            sort_order='reverse')
+        self.assertEqual(
+            parsed, {'Title': {'query': 'Welcome to Plone'}})
+
     def test_path_explicit(self):
         data = {
             'i': 'path',


### PR DESCRIPTION
Otherwise you get a `CatalogError`.