### PR TITLE
Ignore unknown `sort_on` indexes when parsing a query. [master]

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,9 @@ New features:
 
 Bug fixes:
 
+- Ignore unknown ``sort_on`` indexes when parsing a query.
+  Otherwise you get a ``CatalogError``.  [maurits]
+
 - Add Python 2 / 3 compatibility
   [pbauer]
 

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -52,9 +52,12 @@ def parseFormquery(context, formquery, sort_on=None, sort_order=None):
 
     # Add sorting (sort_on and sort_order) to the query
     if sort_on:
-        query['sort_on'] = sort_on
-    if sort_order:
-        query['sort_order'] = sort_order
+        catalog = getToolByName(context, 'portal_catalog')
+        # I get crazy sort_ons like '194' or 'null'.
+        if sort_on in catalog.indexes():
+            query['sort_on'] = sort_on
+            if sort_order:
+                query['sort_order'] = sort_order
     return query
 
 

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -159,6 +159,34 @@ class TestQueryParser(TestQueryParserBase):
         parsed = queryparser.parseFormquery(MockSite(), [data, ])
         self.assertEqual(parsed, {'Title': {'query': 'Welcome to Plone'}})
 
+    def test_sort_on_known(self):
+        data = {
+            'i': 'Title',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': 'Welcome to Plone',
+        }
+        parsed = queryparser.parseFormquery(
+            MockSite(), [data, ],
+            sort_on='sortable_title',
+            sort_order='reverse')
+        self.assertEqual(
+            parsed, {'Title': {'query': 'Welcome to Plone'},
+                     'sort_on': 'sortable_title',
+                     'sort_order': 'reverse'})
+
+    def test_sort_on_unknown(self):
+        data = {
+            'i': 'Title',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': 'Welcome to Plone',
+        }
+        parsed = queryparser.parseFormquery(
+            MockSite(), [data, ],
+            sort_on='unknown',
+            sort_order='reverse')
+        self.assertEqual(
+            parsed, {'Title': {'query': 'Welcome to Plone'}})
+
     def test_path_explicit(self):
         data = {
             'i': 'path',


### PR DESCRIPTION
Otherwise you get a `CatalogError`.