### PR TITLE
Integer criterions: try to convert all input to integers.

### DIFF
--- a/news/93.bugfix
+++ b/news/93.bugfix
@@ -1,0 +1,4 @@
+Integer criterions: try to convert all input to integers.
+Most notably this did not happen for unicode on Python 2.
+So a ``u"42"`` was passed as value to the catalog query, and this matched either all or nothing.
+[maurits]

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -78,9 +78,15 @@ def _all(context, row):
 def _intEqual(context, row):
     values = None
     if type(row.values) is list:
-        values = [int(v) for v in row.values]
-    elif type(row.values) is str:
-        values = int(row.values)
+        try:
+            values = [int(v) for v in row.values]
+        except (ValueError, TypeError, AttributeError):
+            pass
+    elif not isinstance(row.values, int):
+        try:
+            values = int(row.values)
+        except (ValueError, TypeError, AttributeError):
+            pass
     return {row.index: {'query': values, }}
 
 
@@ -119,8 +125,11 @@ def _largerThan(context, row):
 
 def _intLargerThan(context, row):
     value = None
-    if type(row.values) is str:
-        value = int(row.values)
+    if not isinstance(row.values, int):
+        try:
+            value = int(row.values)
+        except (ValueError, TypeError, AttributeError):
+            pass
     tmp = {row.index:
            {
                'query': value,
@@ -142,8 +151,12 @@ def _lessThan(context, row):
 
 def _intLessThan(context, row):
     value = None
-    if type(row.values) is str:
-        value = int(row.values)
+    if not isinstance(row.values, int):
+        try:
+            value = int(row.values)
+        except (ValueError, TypeError, AttributeError):
+            # value = 0
+            pass
     tmp = {row.index:
            {
                'query': value,

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -314,22 +314,64 @@ class TestQueryGenerators(TestQueryParserBase):
         self.assertEqual(parsed, expected)
 
     def test__intEqual(self):
+        # bytes
         data = Row(
             index='modified',
             operator='_intEqual',
-            values='20'
+            values=b'20'
         )
         parsed = queryparser._intEqual(MockSite(), data)
         expected = {'modified': {'query': 20}}
         self.assertEqual(parsed, expected)
 
+        # list of bytes
         data = Row(
             index='modified',
             operator='_intEqual',
-            values=['20', '21']
+            values=[b'20', b'21']
         )
         parsed = queryparser._intEqual(MockSite(), data)
         expected = {'modified': {'query': [20, 21]}}
+        self.assertEqual(parsed, expected)
+
+        # text
+        data = Row(
+            index='modified',
+            operator='_intEqual',
+            values=u'20'
+        )
+        parsed = queryparser._intEqual(MockSite(), data)
+        expected = {'modified': {'query': 20}}
+        self.assertEqual(parsed, expected)
+
+        # list of texts
+        data = Row(
+            index='modified',
+            operator='_intEqual',
+            values=[u'20', u'21']
+        )
+        parsed = queryparser._intEqual(MockSite(), data)
+        expected = {'modified': {'query': [20, 21]}}
+        self.assertEqual(parsed, expected)
+
+        # bad text
+        data = Row(
+            index='modified',
+            operator='_intEqual',
+            values='bad'
+        )
+        parsed = queryparser._intEqual(MockSite(), data)
+        expected = {'modified': {'query': None}}
+        self.assertEqual(parsed, expected)
+
+        # list of bad text
+        data = Row(
+            index='modified',
+            operator='_intEqual',
+            values=[b'bad', 'text', u'values']
+        )
+        parsed = queryparser._intEqual(MockSite(), data)
+        expected = {'modified': {'query': None}}
         self.assertEqual(parsed, expected)
 
     def test__lessThan(self):
@@ -343,13 +385,34 @@ class TestQueryGenerators(TestQueryParserBase):
         self.assertEqual(parsed, expected)
 
     def test__intLessThan(self):
+        # bytes
         data = Row(
             index='modified',
             operator='_intLessThan',
-            values='20'
+            values=b'20'
         )
         parsed = queryparser._intLessThan(MockSite(), data)
         expected = {'modified': {'query': 20, 'range': 'max'}}
+        self.assertEqual(parsed, expected)
+
+        # text
+        data = Row(
+            index='modified',
+            operator='_intLessThan',
+            values=u'20'
+        )
+        parsed = queryparser._intLessThan(MockSite(), data)
+        expected = {'modified': {'query': 20, 'range': 'max'}}
+        self.assertEqual(parsed, expected)
+
+        # bad value
+        data = Row(
+            index='modified',
+            operator='_intLessThan',
+            values='bad'
+        )
+        parsed = queryparser._intLessThan(MockSite(), data)
+        expected = {'modified': {'query': None, 'range': 'max'}}
         self.assertEqual(parsed, expected)
 
     def test__largerThan(self):
@@ -363,13 +426,34 @@ class TestQueryGenerators(TestQueryParserBase):
         self.assertEqual(parsed, expected)
 
     def test__intLargerThan(self):
+        # bytes
         data = Row(
             index='modified',
             operator='_intLargerThan',
-            values='20'
+            values=b'20'
         )
         parsed = queryparser._intLargerThan(MockSite(), data)
         expected = {'modified': {'query': 20, 'range': 'min'}}
+        self.assertEqual(parsed, expected)
+
+        # text
+        data = Row(
+            index='modified',
+            operator='_intLargerThan',
+            values=u'20'
+        )
+        parsed = queryparser._intLargerThan(MockSite(), data)
+        expected = {'modified': {'query': 20, 'range': 'min'}}
+        self.assertEqual(parsed, expected)
+
+        # bad value
+        data = Row(
+            index='modified',
+            operator='_intLargerThan',
+            values='bad'
+        )
+        parsed = queryparser._intLargerThan(MockSite(), data)
+        expected = {'modified': {'query': None, 'range': 'min'}}
         self.assertEqual(parsed, expected)
 
     def test__currentUser(self):


### PR DESCRIPTION
Most notably this did not happen for unicode on Python 2.
So a `u"42"` was passed as value to the catalog query, and this matched either all or nothing.

Fixes https://github.com/plone/plone.app.querystring/issues/93 for Plone 5.1 and 5.2.