### PR TITLE
Fix query update with custom query

### DIFF
--- a/news/103.bugfix
+++ b/news/103.bugfix
@@ -1,0 +1,1 @@
+Fix how to merge custom_query with parsedquery without overriding values. [cekk]

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -160,11 +160,18 @@ class QueryBuilder(BrowserView):
             # Update the parsed query with an extra query dictionary. This may
             # override the parsed query. The custom_query is a dictonary of
             # index names and their associated query values.
-            parsedquery.update(custom_query)
+            for key in custom_query:
+                if key in parsedquery:
+                    if isinstance(parsedquery[key], dict):
+                        parsedquery[key].update(custom_query[key])
+                    else:
+                        parsedquery[key] = custom_query[key]
+                else:
+                    parsedquery[key] = custom_query[key]
             empty_query = False
 
         # filter bad term and operator in query
-        parsedquery =  self.filter_query(parsedquery)
+        parsedquery = self.filter_query(parsedquery)
         results = []
         if not empty_query:
             results = catalog(**parsedquery)

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -161,15 +161,13 @@ class QueryBuilder(BrowserView):
             # override the parsed query. The custom_query is a dictonary of
             # index names and their associated query values.
             for key in custom_query:
-                if key in parsedquery:
-                    if isinstance(parsedquery[key], dict) and isinstance(
-                        custom_query[key], dict
-                    ):
-                        parsedquery[key].update(custom_query[key])
-                    else:
-                        parsedquery[key] = custom_query[key]
-                else:
-                    parsedquery[key] = custom_query[key]
+                if (
+                    isinstance(parsedquery.get(key), dict)
+                    and isinstance(custom_query.get(key), dict)
+                ):
+                    parsedquery[key].update(custom_query[key])
+                    continue
+                parsedquery[key] = custom_query[key]
             empty_query = False
 
         # filter bad term and operator in query

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -162,7 +162,9 @@ class QueryBuilder(BrowserView):
             # index names and their associated query values.
             for key in custom_query:
                 if key in parsedquery:
-                    if isinstance(parsedquery[key], dict):
+                    if isinstance(parsedquery[key], dict) and isinstance(
+                        custom_query[key], dict
+                    ):
                         parsedquery[key].update(custom_query[key])
                     else:
                         parsedquery[key] = custom_query[key]

--- a/plone/app/querystring/tests/testQueryBuilder.py
+++ b/plone/app/querystring/tests/testQueryBuilder.py
@@ -188,6 +188,37 @@ class TestQuerybuilder(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].Title(), 'Test Folder')
 
+    def testQueryBuilderCustomQueryDoNotOverrideValues(self):
+        """Test if custom queries do not override values if they are dicts
+        """
+        self.portal.invokeFactory("Document",
+                                  "collectionstestpage-2",
+                                  title="Collectionstestpage 2")
+        testpage2 = self.portal['collectionstestpage-2']
+        query = [{
+            'i': 'UID',
+            'o': 'plone.app.querystring.operation.string.is',
+            'v': [self.testpage.UID(), testpage2.UID()],
+        }]
+
+        results = self.querybuilder._makequery(query=query)
+        self.assertEqual(len(results), 2)
+        self.assertEqual(results[0].Title(), 'Collectionstestpage')
+        self.assertEqual(results[1].Title(), 'Collectionstestpage 2')
+
+        # if we add new values to the query, they should not be overwritten
+        results = self.querybuilder._makequery(
+            query=query,
+            custom_query={'UID': {'not': testpage2.UID()}})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Title(), 'Collectionstestpage')
+
+        # if we add the same values to the query, they should be overwritten
+        results = self.querybuilder._makequery(
+            query=query,
+            custom_query={'UID': {'query': testpage2.UID()}})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Title(), 'Collectionstestpage 2')
 
 class TestQuerybuilderResultTypes(unittest.TestCase):
 

--- a/plone/app/querystring/tests/testQueryBuilder.py
+++ b/plone/app/querystring/tests/testQueryBuilder.py
@@ -220,6 +220,14 @@ class TestQuerybuilder(unittest.TestCase):
         self.assertEqual(len(results), 1)
         self.assertEqual(results[0].Title(), 'Collectionstestpage 2')
 
+        # add simple custom query
+        results = self.querybuilder._makequery(
+            query=query,
+            custom_query={'UID': testpage2.UID()})
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].Title(), 'Collectionstestpage 2')
+
+
 class TestQuerybuilderResultTypes(unittest.TestCase):
 
     layer = TEST_PROFILE_PLONEAPPQUERYSTRING_INTEGRATION_TESTING


### PR DESCRIPTION
For example when you perform a restapi call to filter by UID and the endpoint automatically add a not query for current context's UID.

With old code we used "update" method that overrides the vale of the query.

