### PR TITLE
Add lazy attribute to vocabularies to prevent fetching any results

### DIFF
--- a/news/104.feature
+++ b/news/104.feature
@@ -1,0 +1,2 @@
+- Add lazy attribute to vocabularies to prevent fetching any results
+  [reebalazs]

--- a/plone/app/querystring/interfaces.py
+++ b/plone/app/querystring/interfaces.py
@@ -28,6 +28,7 @@ class IQueryField(Interface):
     description = Text(title=u"Description")
     enabled = Bool(title=u"Enabled")
     sortable = Bool(title=u"Sortable")
+    lazy = Bool(title=u"Lazy")
     operations = List(title=u"Operations",
                       value_type=DottedName(title=u"Operation ID"))
     vocabulary = TextLine(title=u"Vocabulary")

--- a/plone/app/querystring/interfaces.py
+++ b/plone/app/querystring/interfaces.py
@@ -28,7 +28,7 @@ class IQueryField(Interface):
     description = Text(title=u"Description")
     enabled = Bool(title=u"Enabled")
     sortable = Bool(title=u"Sortable")
-    lazy = Bool(title=u"Lazy")
+    fetch_vocabulary = Bool(title=u"Fetch vocabulary", default=True)
     operations = List(title=u"Operations",
                       value_type=DottedName(title=u"Operation ID"))
     vocabulary = TextLine(title=u"Vocabulary")

--- a/plone/app/querystring/registryreader.py
+++ b/plone/app/querystring/registryreader.py
@@ -84,8 +84,8 @@ class QuerystringRegistryReader(object):
                 logger.info("%s is missing, ignored." % vocabulary)
                 continue
             translated = []
-            if field.get('lazy', False):
-                # Bail out if the annotation is marked as lazy
+            if not field.get('fetch_vocabulary', True):
+                # Bail out if the annotation is marked not to fetch the vocabulary
                 # to allow the widget to query the vocabulary as needed
                 continue
             for item in utility(self.context):

--- a/plone/app/querystring/registryreader.py
+++ b/plone/app/querystring/registryreader.py
@@ -84,6 +84,10 @@ class QuerystringRegistryReader(object):
                 logger.info("%s is missing, ignored." % vocabulary)
                 continue
             translated = []
+            if field.get('lazy', False):
+                # Bail out if the annotation is marked as lazy
+                # to allow the widget to query the vocabulary as needed
+                continue
             for item in utility(self.context):
                 if isinstance(item.title, Message):
                     title = translate(item.title, context=self.request)

--- a/plone/app/querystring/tests/registry_testdata.py
+++ b/plone/app/querystring/tests/registry_testdata.py
@@ -15,7 +15,8 @@ parsed_correct = {
                         'vocabulary': None,
                         'title': u'Short Name',
                         'enabled': True,
-                        'sortable': True
+                        'sortable': True,
+                        'fetch_vocabulary': True
                     },
                     'created': {
                         'operations': [
@@ -28,7 +29,8 @@ parsed_correct = {
                         'vocabulary': None,
                         'title': u'Creation Date',
                         'enabled': True,
-                        'sortable': False
+                        'sortable': False,
+                        'fetch_vocabulary': True
                     }
                 },
                 'operation': {


### PR DESCRIPTION
Huge vocabularies cause serious performance problems in the server
memory, in the network payload, and in the browser, because the large
result set is fetched pointlessly. An application can set lazy=True
for such vocabularies, and at the same time override the operations
from xml to provide an "autocomplete" widget. Such a widget does not
need any initial results but will search and fetch the vocabulary
lazily, on demand.

The use case targets Volto sites, but the problem is not specific to
Volto.