### PR TITLE
Fixes #111 for branch 1.x

### DIFF
--- a/news/111.bugfix
+++ b/news/111.bugfix
@@ -1,0 +1,2 @@
+Make SearchableText work when using 'and' and 'or' as search items
+[erral]

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -15,21 +15,34 @@ from zope.publisher.browser import BrowserView
 
 import json
 import logging
+import re
 
 
-logger = logging.getLogger('plone.app.querystring')
-_ = MessageFactory('plone')
+logger = logging.getLogger("plone.app.querystring")
+_ = MessageFactory("plone")
 
-BAD_CHARS = ('?', '-', '+', '*')
+MULTISPACE = "\u3000"
+BAD_CHARS = ("?", "-", "+", "*", MULTISPACE)
 
 
 def quote_chars(s):
     # We need to quote parentheses when searching text indices
-    if '(' in s:
-        s = s.replace('(', '"("')
-    if ')' in s:
-        s = s.replace(')', '")"')
+    if "(" in s:
+        s = s.replace("(", '"("')
+    if ")" in s:
+        s = s.replace(")", '")"')
+    if MULTISPACE in s:
+        s = s.replace(MULTISPACE, " ")
     return s
+
+
+def quote(term):
+    # The terms and, or and not must be wrapped in quotes to avoid
+    # being parsed as logical query atoms.
+    if term.lower() in ("and", "or", "not"):
+        term = '"%s"' % term
+    return term
+
 
 class ContentListingView(BrowserView):
     """BrowserView for displaying query results"""
@@ -39,16 +52,25 @@ class ContentListingView(BrowserView):
 
 
 class QueryBuilder(BrowserView):
-    """ This view is used by the javascripts,
-        fetching configuration or results"""
+    """This view is used by the javascripts,
+    fetching configuration or results"""
 
     def __init__(self, context, request):
         super(QueryBuilder, self).__init__(context, request)
         self._results = None
 
-    def __call__(self, query, batch=False, b_start=0, b_size=30,
-                 sort_on=None, sort_order=None, limit=0, brains=False,
-                 custom_query=None):
+    def __call__(
+        self,
+        query,
+        batch=False,
+        b_start=0,
+        b_size=30,
+        sort_on=None,
+        sort_order=None,
+        limit=0,
+        brains=False,
+        custom_query=None,
+    ):
         """Create a zope catalog query and return results.
 
         :param query: The querystring to be parsed into a zope catalog query.
@@ -95,32 +117,45 @@ class QueryBuilder(BrowserView):
                 sort_order=sort_order,
                 limit=limit,
                 brains=brains,
-                custom_query=custom_query)
+                custom_query=custom_query,
+            )
         return self._results
 
     def html_results(self, query):
         """html results, used for in the edit screen of a collection,
-           used in the live update results"""
+        used in the live update results"""
         options = dict(original_context=self.context)
-        results = self(query, sort_on=self.request.get('sort_on', None),
-                       sort_order=self.request.get('sort_order', None),
-                       limit=10)
+        results = self(
+            query,
+            sort_on=self.request.get("sort_on", None),
+            sort_order=self.request.get("sort_order", None),
+            limit=10,
+        )
 
         return getMultiAdapter(
-            (results, self.request),
-            name='display_query_results'
+            (results, self.request), name="display_query_results"
         )(**options)
 
-    def _makequery(self, query=None, batch=False, b_start=0, b_size=30,
-                   sort_on=None, sort_order=None, limit=0, brains=False,
-                   custom_query=None):
+    def _makequery(
+        self,
+        query=None,
+        batch=False,
+        b_start=0,
+        b_size=30,
+        sort_on=None,
+        sort_order=None,
+        limit=0,
+        brains=False,
+        custom_query=None,
+    ):
         """Parse the (form)query and return using multi-adapter"""
         query_modifiers = getUtilitiesFor(IQueryModifier)
         for name, modifier in sorted(query_modifiers, key=itemgetter(0)):
             query = modifier(query)
 
         parsedquery = queryparser.parseFormquery(
-            self.context, query, sort_on, sort_order)
+            self.context, query, sort_on, sort_order
+        )
 
         index_modifiers = getUtilitiesFor(IParsedQueryIndexModifier)
         for name, modifier in index_modifiers:
@@ -134,36 +169,37 @@ class QueryBuilder(BrowserView):
                     parsedquery[new_name] = query
 
         # Check for valid indexes
-        catalog = getToolByName(self.context, 'portal_catalog')
-        valid_indexes = [index for index in parsedquery
-                         if index in catalog.indexes()]
+        catalog = getToolByName(self.context, "portal_catalog")
+        valid_indexes = [
+            index for index in parsedquery if index in catalog.indexes()
+        ]
 
         # We'll ignore any invalid index, but will return an empty set if none
         # of the indexes are valid.
         if not valid_indexes:
             logger.warning(
-                "Using empty query because there are no valid indexes used.")
+                "Using empty query because there are no valid indexes used."
+            )
             parsedquery = {}
 
         empty_query = not parsedquery  # store emptiness
 
         if batch:
-            parsedquery['b_start'] = b_start
-            parsedquery['b_size'] = b_size
+            parsedquery["b_start"] = b_start
+            parsedquery["b_size"] = b_size
         elif limit:
-            parsedquery['sort_limit'] = limit
+            parsedquery["sort_limit"] = limit
 
-        if 'path' not in parsedquery:
-            parsedquery['path'] = {'query': ''}
+        if "path" not in parsedquery:
+            parsedquery["path"] = {"query": ""}
 
         if isinstance(custom_query, dict) and custom_query:
             # Update the parsed query with an extra query dictionary. This may
             # override the parsed query. The custom_query is a dictonary of
             # index names and their associated query values.
             for key in custom_query:
-                if (
-                    isinstance(parsedquery.get(key), dict)
-                    and isinstance(custom_query.get(key), dict)
+                if isinstance(parsedquery.get(key), dict) and isinstance(
+                    custom_query.get(key), dict
                 ):
                     parsedquery[key].update(custom_query[key])
                     continue
@@ -175,8 +211,11 @@ class QueryBuilder(BrowserView):
         results = []
         if not empty_query:
             results = catalog(**parsedquery)
-            if getattr(results, 'actual_result_count', False) and limit\
-                    and results.actual_result_count > limit:
+            if (
+                getattr(results, "actual_result_count", False)
+                and limit
+                and results.actual_result_count > limit
+            ):
                 results.actual_result_count = limit
 
         if not brains:
@@ -189,26 +228,42 @@ class QueryBuilder(BrowserView):
         """Get the number of results"""
         results = self(query, sort_on=None, sort_order=None, limit=1)
         return translate(
-            _(u"batch_x_items_matching_your_criteria",
-              default=u"${number} items matching your search terms.",
-              mapping={'number': results.actual_result_count}),
-            context=self.request
+            _(
+                u"batch_x_items_matching_your_criteria",
+                default=u"${number} items matching your search terms.",
+                mapping={"number": results.actual_result_count},
+            ),
+            context=self.request,
         )
 
     def filter_query(self, query):
-        text = query.get('SearchableText', None)
+        text = query.get("SearchableText", None)
         if isinstance(text, dict):
-            text = text.get('query', '')
+            text = text.get("query", "")
         if text:
-            query['SearchableText'] = self.munge_search_term(text)
+            query["SearchableText"] = self.munge_search_term(text)
         return query
 
-    def munge_search_term(self, q):
+    def munge_search_term(query):
         for char in BAD_CHARS:
-            q = q.replace(char, ' ')
-        r = q.split()
+            query = query.replace(char, " ")
+
+        # extract quoted phrases first
+        quoted_phrases = re.findall(r'"([^"]*)"', query)
+        r = []
+        for qp in quoted_phrases:
+            # remove from original query
+            query = query.replace('"{qp}"'.format(qp=qp), "")
+            # replace with cleaned leading/trailing whitespaces
+            # and skip empty phrases
+            clean_qp = qp.strip()
+            if not clean_qp:
+                continue
+            r.append('"{clean_qp}"'.format(clean_qp=clean_qp))
+
+        r += map(quote, query.strip().split())
         r = " AND ".join(r)
-        r = quote_chars(r) + '*'
+        r = quote_chars(r) + ("*" if r and not r.endswith('"') else "")
         return r
 
 
@@ -216,6 +271,7 @@ class RegistryConfiguration(BrowserView):
     def __call__(self):
         registry = getUtility(IRegistry)
         reader = getMultiAdapter(
-            (registry, self.request), IQuerystringRegistryReader)
+            (registry, self.request), IQuerystringRegistryReader
+        )
         data = reader()
         return json.dumps(data)

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -13,7 +13,7 @@ from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
 from zope.publisher.browser import BrowserView
 
-import jso
+import json
 import logging
 import re
 

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -13,7 +13,7 @@ from zope.i18n import translate
 from zope.i18nmessageid import MessageFactory
 from zope.publisher.browser import BrowserView
 
-import json
+import jso
 import logging
 import re
 
@@ -244,7 +244,7 @@ class QueryBuilder(BrowserView):
             query["SearchableText"] = self.munge_search_term(text)
         return query
 
-    def munge_search_term(query):
+    def munge_search_term(self, query):
         for char in BAD_CHARS:
             query = query.replace(char, " ")
 

--- a/plone/app/querystring/tests/testQueryBuilder.py
+++ b/plone/app/querystring/tests/testQueryBuilder.py
@@ -209,6 +209,48 @@ class TestQuerybuilder(unittest.TestCase):
             results[0].getObject().Subject(),
             ('Äüö',))
 
+    def testMakeQueryWithSearchableText(self):
+        query = [{
+            'i': 'SearchableText',
+            'o': 'plone.app.querystring.operation.string.contains',
+            'v': u'Test',
+        }]
+        results = self.querybuilder._makequery(query=query)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(
+            results[0].getURL(),
+            'http://nohost/plone/testfolder')
+
+    def testMakeQueryWithSearchableTextSpecialWordsAnd(self):
+        self.testpage.description = 'This and that is the description'
+        self.testpage.reindexObject()
+        query = [{
+            'i': 'SearchableText',
+            'o': 'plone.app.querystring.operation.string.contains',
+            'v': u'This and that',
+        }]
+        results = self.querybuilder._makequery(query=query)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(
+            results[0].getURL(),
+            'http://nohost/plone/collectionstestpage')
+
+    def testMakeQueryWithSearchableTextSpecialWordsOr(self):
+        self.testpage.description = 'This or that is the description'
+        self.testpage.reindexObject()
+        query = [{
+            'i': 'SearchableText',
+            'o': 'plone.app.querystring.operation.string.contains',
+            'v': u'This or that',
+        }]
+        results = self.querybuilder._makequery(query=query)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(
+            results[0].getURL(),
+            'http://nohost/plone/collectionstestpage')
+
+
+
     def testQueryBuilderCustomQuery(self):
         """Test, if custom queries are respected when getting the results.
         """


### PR DESCRIPTION
I just copied over the function `munge_search_terms` from https://github.com/plone/Products.CMFPlone/pull/3518

We are using the same plone.app.querystring version for both Plone 5.2.x and 6, so it is not possible to import from Products.CMFPlone and neither from plone.base if that function is ever moved to there.

Opinions? @petschki @jensens @mauritsvanrees  