### PR TITLE
Fix a circular dependency to plone.app.vocabularies

### DIFF
--- a/news/fix-circular-dep-pavocabularies.bugfix
+++ b/news/fix-circular-dep-pavocabularies.bugfix
@@ -1,0 +1,5 @@
+Fix a circular transitive dependency to `plone.app.querystring`.
+New direct dependency explicit on `plone.app.vocabularies`.
+Move `plone.app.querystring.catalog.CatalogVocabularyFactory` to `.vocabularies`, move the ZCML to register the factory, move the the test.
+Move `plone.app.querystring.utils.parse_query` with new name `parseAndModifyFormquery` to `.queryparser`.
+[@jensens]

--- a/plone/app/querystring/configure.zcml
+++ b/plone/app/querystring/configure.zcml
@@ -64,4 +64,8 @@
       name="1000"
       component=".querymodifiers.modify_query_to_enforce_navigation_root"
       />
+  <utility
+      factory=".vocabularies.CatalogVocabularyFactory"
+      name="plone.app.vocabularies.Catalog"
+      />
 </configure>

--- a/plone/app/querystring/tests/testVocabularies.py
+++ b/plone/app/querystring/tests/testVocabularies.py
@@ -1,0 +1,19 @@
+from plone.app.vocabularies.tests.test_vocabularies import vocabSetUp
+from plone.app.vocabularies.tests.test_vocabularies import vocabTearDown
+
+import doctest
+import unittest
+
+
+def test_suite():
+    optionflags = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
+    return unittest.TestSuite(
+        (
+            doctest.DocTestSuite(
+                "plone.app.vocabularies.catalog",
+                setUp=vocabSetUp,
+                tearDown=vocabTearDown,
+                optionflags=optionflags,
+            ),
+        )
+    )

--- a/plone/app/querystring/vocabularies.py
+++ b/plone/app/querystring/vocabularies.py
@@ -1,0 +1,63 @@
+from .queryparser import parseAndModifyFormquery
+from plone.app.vocabularies.catalog import CatalogVocabulary
+from plone.base.navigationroot import get_navigation_root_object
+from zope.component.hooks import getSite
+from zope.interface import implementer
+from zope.schema.interfaces import IVocabularyFactory
+
+
+# this vocabulary is in this package by intend.
+# since plone.app.querystring depends on plone.app.vocabularies
+# we can not put it over there without creating a circular dependency.
+
+
+@implementer(IVocabularyFactory)
+class CatalogVocabularyFactory:
+    """
+    Test application of Navigation Root:
+
+      >>> from plone.app.vocabularies.tests.base import create_context
+      >>> from plone.app.vocabularies.tests.base import DummyUrlTool
+      >>> from plone.app.vocabularies.tests.base import DummyCatalog
+      >>> class DummyPathCatalog(DummyCatalog):
+      ...     def __call__(self, **query):
+      ...         if 'path' in query and 'query' in query['path']:
+      ...             return [v for v in self.values() if
+      ...                     v.getPath().startswith(query['path']['query'])]
+      ...         return self.values()
+      >>> catalog = DummyPathCatalog(['/abcd', '/defg', '/dummy/sub-site',
+      ...                             '/dummy/sub-site/ghij'])
+      >>> context = create_context()
+      >>> context.portal_catalog = catalog
+      >>> context.portal_url = DummyUrlTool(context)
+      >>> factory = CatalogVocabularyFactory()
+
+      >>> sorted(t.token for t in factory(context))
+      ['/abcd', '/defg', '/dummy/sub-site', '/dummy/sub-site/ghij']
+
+      >>> from plone.app.vocabularies.tests.base import DummyNavRoot
+      >>> nav_root = DummyNavRoot('sub-site', parent=context)
+      >>> [t.token for t in factory(nav_root)]
+      ['/dummy/sub-site', '/dummy/sub-site/ghij']
+
+    """
+
+    def __call__(self, context, query=None):
+        parsed = {}
+        if query:
+            parsed = parseAndModifyFormquery(context, query["criteria"])
+            if "sort_on" in query:
+                parsed["sort_on"] = query["sort_on"]
+            if "sort_order" in query:
+                parsed["sort_order"] = str(query["sort_order"])
+
+        if "path" not in parsed:
+            site = getSite()
+            nav_root = get_navigation_root_object(context, site)
+            site_path = site.getPhysicalPath()
+            if nav_root and nav_root.getPhysicalPath() != site_path:
+                parsed["path"] = {
+                    "query": "/".join(nav_root.getPhysicalPath()),
+                    "depth": -1,
+                }
+        return CatalogVocabulary.fromItems(parsed, context)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         "setuptools",
         "plone.app.contentlisting",
         "plone.app.registry>=1.1",
+        "plone.app.vocabularies",
         "plone.base",
         "plone.batching",
         "plone.i18n",


### PR DESCRIPTION
- New direct dependency explicit on `plone.app.vocabularies`.
- Move `plone.app.vocabularies.catalog.CatalogVocabularyFactory` to `.vocabularies`, move the ZCML to register the factory, move the the test.
- Move `plone.app.vocabularies.utils.parse_query` with new name `parseAndModifyFormquery` to `.queryparser`.

Has to be tested and merged together with https://github.com/plone/plone.app.vocabularies/pull/76
GHA test will fail.