### PR TITLE
Merge multiple range queries

### DIFF
--- a/news/132.bugfix
+++ b/news/132.bugfix
@@ -1,0 +1,1 @@
+Merge range queries on the same index instead of overwriting. @davisagli

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -64,9 +64,8 @@ def parseFormquery(context, formquery, sort_on=None, sort_order=None):
                     if not isinstance(new_query, list):
                         new_query = [new_query]
                     existing["query"] = sorted(existing_query + new_query)
-                    if (
-                        (existing["range"] == "min" and value["range"] == "max") or
-                        (existing["range"] == "max" and value["range"] == "min")
+                    if (existing["range"] == "min" and value["range"] == "max") or (
+                        existing["range"] == "max" and value["range"] == "min"
                     ):
                         existing["range"] = "minmax"
                     continue

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -37,7 +37,6 @@ def parseFormquery(context, formquery, sort_on=None, sort_order=None):
             index=row.get("i", None), operator=function_path, values=row.get("v", None)
         )
 
-        kwargs = {}
         parser = resolve(row.operator)
         kwargs = parser(context, row)
 
@@ -49,10 +48,30 @@ def parseFormquery(context, formquery, sort_on=None, sort_order=None):
                 query[path_index]["query"].extend(kwargs[path_index]["query"])
             else:
                 query.update(kwargs)
+            continue
         elif len(path_index) > 1:
             raise IndexError("Too many path indices in one row.")
-        else:
-            query.update(kwargs)
+
+        for index, value in kwargs.items():
+            # Merge range queries on the same index
+            if isinstance(value, dict) and "range" in value:
+                existing = query.get(index)
+                if isinstance(existing, dict) and "range" in existing:
+                    existing_query = existing["query"]
+                    if not isinstance(existing_query, list):
+                        existing_query = [existing_query]
+                    new_query = value["query"]
+                    if not isinstance(new_query, list):
+                        new_query = [new_query]
+                    existing["query"] = sorted(existing_query + new_query)
+                    if (
+                        (existing["range"] == "min" and value["range"] == "max") or
+                        (existing["range"] == "max" and value["range"] == "min")
+                    ):
+                        existing["range"] = "minmax"
+                    continue
+            # Other cases: simply overwrite the query for the index
+            query[index] = value
 
     if not query:
         # If the query is empty fall back onto the equality query

--- a/plone/app/querystring/tests/testQueryParser.py
+++ b/plone/app/querystring/tests/testQueryParser.py
@@ -285,6 +285,22 @@ class TestQueryParser(TestQueryParserBase):
             },
         )
 
+    def test_merge_ranges(self):
+        data = [
+            {
+                "i": "modified",
+                "o": "plone.app.querystring.operation.int.largerThan",
+                "v": 10,
+            },
+            {
+                "i": "modified",
+                "o": "plone.app.querystring.operation.int.lessThan",
+                "v": 20,
+            },
+        ]
+        parsed = queryparser.parseFormquery(MockSite(), data)
+        self.assertEqual(parsed, {"modified": {"query": [10, 20], "range": "minmax"}})
+
 
 class TestQueryGenerators(TestQueryParserBase):
     def test__between(self):


### PR DESCRIPTION
If one query operation performs a min range query and another performs a max range query on the same index, merge them together into a minmax. Fixes #130.

Note: depends on https://github.com/plone/plone.app.querystring/pull/131