### PR TITLE
Support getting querystring vocabs in context

### DIFF
--- a/news/137.feature
+++ b/news/137.feature
@@ -1,0 +1,1 @@
+Add a way to specific a context for getting vocabularies in the QuerystringRegistryReader. @davisagli

--- a/plone/app/querystring/registryreader.py
+++ b/plone/app/querystring/registryreader.py
@@ -42,6 +42,7 @@ class QuerystringRegistryReader:
             request = getRequest()
 
         self.context = context
+        self.vocab_context = context
         self.request = request
 
     def parseRegistry(self):
@@ -87,7 +88,7 @@ class QuerystringRegistryReader:
                 # Bail out if the annotation is marked not to fetch the vocabulary
                 # to allow the widget to query the vocabulary as needed
                 continue
-            for item in utility(self.context):
+            for item in utility(self.vocab_context):
                 if isinstance(item.title, Message):
                     title = translate(item.title, context=self.request)
                 else:

--- a/plone/app/querystring/tests/testRegistryReader.py
+++ b/plone/app/querystring/tests/testRegistryReader.py
@@ -15,7 +15,8 @@ import unittest
 @implementer(IVocabularyFactory)
 class TestVocabulary:
     def __call__(self, context):
-        return SimpleVocabulary([SimpleVocabulary.createTerm("foo", "foo", "bar")])
+        term = "subsite term" if getattr(context, "id", None) == "subsite" else "term"
+        return SimpleVocabulary([SimpleVocabulary.createTerm(term, term, term)])
 
 
 class TestRegistryReader(unittest.TestCase):
@@ -82,7 +83,19 @@ class TestRegistryReader(unittest.TestCase):
         result = reader.parseRegistry()
         result = reader.getVocabularyValues(result)
         vocabulary_result = result.get("plone.app.querystring.field.reviewState.values")
-        self.assertEqual(vocabulary_result, {"foo": {"title": "bar"}})
+        self.assertEqual(vocabulary_result, {"term": {"title": "term"}})
+
+    def test_get_vocabularies_in_context(self):
+        portal = self.layer["portal"]
+        subsite = portal[portal.invokeFactory("Document", "subsite", title="Subsite")]
+
+        registry = self.createRegistry(td.test_vocabulary_xml)
+        reader = IQuerystringRegistryReader(registry)
+        reader.vocab_context = subsite
+        result = reader.parseRegistry()
+        result = reader.getVocabularyValues(result)
+        vocabulary_result = result.get("plone.app.querystring.field.reviewState.values")
+        self.assertEqual(vocabulary_result, {"subsite term": {"title": "subsite term"}})
 
     def test_map_operations_clean(self):
         """tests if mapOperations is getting all operators correctly"""


### PR DESCRIPTION
Add a way to get querystring info with vocabularies fetched in a specific context.

(This doesn't change anything on its own. I'm going to make a related PR in plone.restapi which uses it.)