### PR TITLE
Create string search operator

### DIFF
--- a/plone/app/querystring/profiles.zcml
+++ b/plone/app/querystring/profiles.zcml
@@ -90,4 +90,12 @@
       directory="profiles/upgrades/to_14"
       />
 
+  <genericsetup:registerProfile
+      name="upgrade_to_15"
+      title="Querystring Upgrade profile to v15"
+      description=""
+      provides="Products.GenericSetup.interfaces.EXTENSION"
+      directory="profiles/upgrades/to_15"
+      />
+
 </configure>

--- a/plone/app/querystring/profiles/default/metadata.xml
+++ b/plone/app/querystring/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <metadata>
-  <version>14</version>
+  <version>15</version>
   <dependencies>
     <dependency>profile-plone.app.registry:default</dependency>
   </dependencies>

--- a/plone/app/querystring/profiles/default/registry.xml
+++ b/plone/app/querystring/profiles/default/registry.xml
@@ -803,6 +803,7 @@
     <value key="sortable">False</value>
     <value key="operations">
       <element>plone.app.querystring.operation.string.contains</element>
+      <element>plone.app.querystring.operation.string.search</element>
     </value>
     <value key="group"
            i18n:translate=""

--- a/plone/app/querystring/profiles/default/registry.xml
+++ b/plone/app/querystring/profiles/default/registry.xml
@@ -242,6 +242,14 @@
     <value key="operation">plone.app.querystring.queryparser._contains</value>
     <value key="widget">StringWidget</value>
   </records>
+  
+  <records interface="plone.app.querystring.interfaces.IQueryOperation"
+      prefix="plone.app.querystring.operation.string.search">
+      <value key="title" i18n:translate="">Search</value>
+      <value key="description"></value>
+      <value key="operation">plone.app.querystring.queryparser._search</value>
+      <value key="widget">StringWidget</value>
+  </records>
 
   <records interface="plone.app.querystring.interfaces.IQueryOperation"
            prefix="plone.app.querystring.operation.string.currentUser"

--- a/plone/app/querystring/profiles/upgrades/to_15/registry.xml
+++ b/plone/app/querystring/profiles/upgrades/to_15/registry.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<registry xmlns:i18n="http://xml.zope.org/namespaces/i18n"
+          i18n:domain="plone"
+>
+  <records interface="plone.app.querystring.interfaces.IQueryOperation"
+      prefix="plone.app.querystring.operation.string.search">
+      <value key="title" i18n:translate="">Search</value>
+      <value key="description"></value>
+      <value key="operation">plone.app.querystring.queryparser._search</value>
+      <value key="widget">StringWidget</value>
+  </records>
+
+ <records interface="plone.app.querystring.interfaces.IQueryField"
+           prefix="plone.app.querystring.field.SearchableText"
+           purge="False"
+  >
+    <value key="operations"
+           purge="False"
+    >
+      <element>plone.app.querystring.operation.string.search</element>
+    </value>
+  </records>
+</registry>

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -265,6 +265,8 @@ class QueryBuilder(BrowserView):
         if isinstance(text, dict):
             if text.get("operator", "") == "search":
                 munge = False
+                # catalog searches don't accept the operator key so remove it
+                del text["operator"]
             text = text.get("query", "")
         if text and munge:
             query["SearchableText"] = self.munge_search_term(text)

--- a/plone/app/querystring/querybuilder.py
+++ b/plone/app/querystring/querybuilder.py
@@ -261,9 +261,12 @@ class QueryBuilder(BrowserView):
 
     def filter_query(self, query):
         text = query.get("SearchableText", None)
+        munge = True
         if isinstance(text, dict):
+            if text.get("operator", "") == "search":
+                munge = False
             text = text.get("query", "")
-        if text:
+        if text and munge:
             query["SearchableText"] = self.munge_search_term(text)
         return query
 

--- a/plone/app/querystring/queryparser.py
+++ b/plone/app/querystring/queryparser.py
@@ -110,6 +110,9 @@ def parseAndModifyFormquery(context, query, sort_on=None, sort_order=None):
 def _contains(context, row):
     return _equal(context, row)
 
+def _search(context, row):
+    return {row.index: {'query': row.values, 'operator': 'search' }}
+
 
 def _excludes(context, row):
     return {row.index: {"not": row.values}}

--- a/plone/app/querystring/upgrades.zcml
+++ b/plone/app/querystring/upgrades.zcml
@@ -157,6 +157,16 @@
         title="Add new 'string.isNot' and 'selection.none' query operators."
         import_profile="plone.app.querystring:upgrade_to_14"
         />
+ </genericsetup:upgradeSteps>
+   <genericsetup:upgradeSteps
+      profile="plone.app.querystring:default"
+      source="14"
+      destination="15"
+      >
+    <genericsetup:upgradeDepends
+        title="Add new 'string.search' query operator."
+        import_profile="plone.app.querystring:upgrade_to_15"
+        />
   </genericsetup:upgradeSteps>
 
 </configure>


### PR DESCRIPTION
Currently the only operator for searching strings is the `contains` operator which modifies the search term before running the query.

The creation of a search operator allows a search to be performed without munging the search term. This allows for exact matching in searches.

The primary use case for driving this PR is to be able to provide the search term to collective.elasticsearch without modification so that elastic can be used to parse the search original phrase.