### PR TITLE
Fix tests for `not` queries in Products.ZCatalog 7.2.0+.

### DIFF
--- a/news/+130d79d1.tests.rst
+++ b/news/+130d79d1.tests.rst
@@ -1,0 +1,1 @@
+Fix tests for ``not`` queries in ``Products.ZCatalog`` 7.2.0+.  [maurits]

--- a/src/plone/app/querystring/tests/testQueryBuilder.py
+++ b/src/plone/app/querystring/tests/testQueryBuilder.py
@@ -123,8 +123,12 @@ class TestQuerybuilder(unittest.TestCase):
             }
         ]
         results = self.querybuilder._makequery(query=query)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].getURL(), "http://nohost/plone/testfolder")
+        # We used to expect 1 result.  But in fact the Plone Site should also
+        # be in the results.  This happens since Products.ZCatalog 7.2.0.
+        self.assertEqual(
+            sorted([brain.getURL() for brain in results]),
+            ["http://nohost/plone", "http://nohost/plone/testfolder"],
+        )
 
     def testMakeQueryWithMultipleSubject(self):
         self.testpage.setSubject(["Lorem"])
@@ -153,8 +157,12 @@ class TestQuerybuilder(unittest.TestCase):
             }
         ]
         results = self.querybuilder._makequery(query=query)
-        self.assertEqual(len(results), 1)
-        self.assertEqual(results[0].getURL(), "http://nohost/plone/testfolder")
+        # We used to expect 1 result.  But in fact the Plone Site should also
+        # be in the results.  This happens since Products.ZCatalog 7.2.0.
+        self.assertEqual(
+            sorted([brain.getURL() for brain in results]),
+            ["http://nohost/plone", "http://nohost/plone/testfolder"],
+        )
 
     def testMakeQueryWithSubjectWithSpecialCharacters(self):
         self.testpage.setSubject(["Äüö"])


### PR DESCRIPTION
See for example this [failure on Jenkins](https://jenkins.plone.org/job/pull-request-6.2-3.13/426/testReport/junit/plone.app.querystring.tests.testQueryBuilder/TestQuerybuilder/testMakeQueryWithMultipleSubjectNot/).  The test created two content items with Subjects, and querying for all items without a specific Subject.  This used to return 1 item.  But now it returns 2, because the Plone Site object is also returned, which has no Subject set.  This object used to be ignored in the catalog.  See https://github.com/zopefoundation/Products.ZCatalog/issues/148

What is a bit strange, is that the 'not' query does not return any results when I run it at the beginning of this test, so before any item with this Subject has been set.  That might be a problem in ZCatalog still.

Note that the GitHub Actions tests will fail because they use an older Products.ZCatalog.  So I am making a PR in `buildout.coredev` to update the pin and make a checkouts of this PR branch.  If that is green, I can merge this PR, and update the ZCatalog pin in the coredev buildout and dist.plone.org.