### PR TITLE
Don't validate sort_on prematurely [backport for Plone 6.1]

### DIFF
--- a/news/173.bugfix
+++ b/news/173.bugfix
@@ -1,0 +1,1 @@
+Don't ignore sort_on values which are not ZCatalog indexes. @davisagli

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
         "plone.registry",
         "plone.uuid",
         "Products.GenericSetup",
-        "Products.ZCatalog",
         "python-dateutil",
         "Zope",
         "zope.dottedname",

--- a/src/plone/app/querystring/queryparser.py
+++ b/src/plone/app/querystring/queryparser.py
@@ -78,12 +78,9 @@ def parseFormquery(context, formquery, sort_on=None, sort_order=None):
 
     # Add sorting (sort_on and sort_order) to the query
     if sort_on:
-        catalog = getToolByName(context, "portal_catalog")
-        # I get crazy sort_ons like '194' or 'null'.
-        if sort_on in catalog.indexes():
-            query["sort_on"] = sort_on
-            if sort_order:
-                query["sort_order"] = sort_order
+        query["sort_on"] = sort_on
+        if sort_order:
+            query["sort_order"] = sort_order
     return query
 
 

--- a/src/plone/app/querystring/registryreader.py
+++ b/src/plone/app/querystring/registryreader.py
@@ -2,11 +2,8 @@ from collections import OrderedDict
 from plone.app.querystring.interfaces import IQuerystringRegistryReader
 from plone.base.utils import safe_text
 from plone.i18n.normalizer.interfaces import IIDNormalizer
-from Products.CMFCore.utils import getToolByName
-from Products.ZCTextIndex.interfaces import IZCTextIndex
 from zope.component import getUtility
 from zope.component import queryUtility
-from zope.component.hooks import getSite
 from zope.globalrequest import getRequest
 from zope.i18n import translate
 from zope.i18nmessageid import Message
@@ -117,14 +114,9 @@ class QuerystringRegistryReader:
 
     def mapSortableIndexes(self, values):
         """Map sortable indexes"""
-        catalog = getToolByName(getSite(), "portal_catalog")._catalog
         sortables = {}
         for key, field in values.get("%s.field" % self.prefix).items():
-            if (
-                field["sortable"]
-                and key in catalog.indexes
-                and not IZCTextIndex.providedBy(catalog.getIndex(key))
-            ):
+            if field["sortable"]:
                 sortables[key] = values.get(f"{self.prefix}.field.{key}")
         values["sortable"] = sortables
         return values

--- a/src/plone/app/querystring/tests/testQueryBuilder.py
+++ b/src/plone/app/querystring/tests/testQueryBuilder.py
@@ -411,6 +411,10 @@ class TestQuerybuilder(unittest.TestCase):
         for _in, _out in search_term_tests:
             self.assertEqual(munge_search_term(_in), _out)
 
+    def test_query_builder_unknown_sort(self):
+        results = self.querybuilder(query=self.query, sort_on="unknown")
+        self.assertEqual(len(results), 1)
+
 
 class TestQuerybuilderResultTypes(unittest.TestCase):
     layer = TEST_PROFILE_PLONEAPPQUERYSTRING_INTEGRATION_TESTING

--- a/src/plone/app/querystring/tests/testQueryParser.py
+++ b/src/plone/app/querystring/tests/testQueryParser.py
@@ -191,7 +191,14 @@ class TestQueryParser(TestQueryParserBase):
             sort_on="unknown",
             sort_order="reverse",
         )
-        self.assertEqual(parsed, {"Title": {"query": "Welcome to Plone"}})
+        self.assertEqual(
+            parsed,
+            {
+                "Title": {"query": "Welcome to Plone"},
+                "sort_on": "unknown",
+                "sort_order": "reverse",
+            },
+        )
 
     def test_path_explicit(self):
         data = {


### PR DESCRIPTION
Backport of https://github.com/plone/plone.app.querystring/issues/173

I was using plone.app.querystring 3.0.0a2 with a Plone 6.1 site in order to have this fix, but now there is plone.app.querystring 3.0.0a3 which is no longer compatible because it depends on something new in plone.base. So I'd better actually do the backport...